### PR TITLE
include software specification list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ metadata = {
 }
 ```
 
+Optionally, to get a list of software specifications run the following:
+
+```python
+client.software_specifications.list()
+```
+
 ## 5. Storing a model (remains same)
 
 


### PR DESCRIPTION
This change includes an optional call to list software specifications that are available to the user should scikit-learn not be what they are using they'll be able to find a replacement.